### PR TITLE
[TEST] Use dedicated `assertCount` for test assertions

### DIFF
--- a/tests/Mods/Reader/AccessConditionReaderTest.php
+++ b/tests/Mods/Reader/AccessConditionReaderTest.php
@@ -28,7 +28,7 @@ class AccessConditionReaderTest extends ModsReaderTest
     {
         $accessConditions = $this->bookReader->getAccessConditions();
         self::assertNotEmpty($accessConditions);
-        self::assertEquals(1, count($accessConditions));
+        self::assertCount(1, $accessConditions);
         self::assertAccessConditionForBookDocument($accessConditions[0]);
     }
 
@@ -66,7 +66,7 @@ class AccessConditionReaderTest extends ModsReaderTest
     {
         $accessConditions = $this->bookReader->getAccessConditions('[@type="use and reproduction"]');
         self::assertNotEmpty($accessConditions);
-        self::assertEquals(1, count($accessConditions));
+        self::assertCount(1, $accessConditions);
         self::assertAccessConditionForBookDocument($accessConditions[0]);
     }
 
@@ -131,7 +131,7 @@ class AccessConditionReaderTest extends ModsReaderTest
     {
         $accessConditions = $this->serialReader->getAccessConditions();
         self::assertNotEmpty($accessConditions);
-        self::assertEquals(1, count($accessConditions));
+        self::assertCount(1, $accessConditions);
         self::assertAccessConditionForSerialDocument($accessConditions[0]);
     }
 
@@ -142,7 +142,7 @@ class AccessConditionReaderTest extends ModsReaderTest
     {
         $accessConditions = $this->serialReader->getAccessConditions('[@type="restriction on access"]');
         self::assertNotEmpty($accessConditions);
-        self::assertEquals(1, count($accessConditions));
+        self::assertCount(1, $accessConditions);
         self::assertAccessConditionForSerialDocument($accessConditions[0]);
     }
 

--- a/tests/Mods/Reader/ClassificationReaderTest.php
+++ b/tests/Mods/Reader/ClassificationReaderTest.php
@@ -28,7 +28,7 @@ class ClassificationReaderTest extends ModsReaderTest
     {
         $classifications = $this->bookReader->getClassifications();
         self::assertNotEmpty($classifications);
-        self::assertEquals(2, count($classifications));
+        self::assertCount(2, $classifications);
         self::assertFirstClassificationForBookDocument($classifications[0]);
     }
 
@@ -66,7 +66,7 @@ class ClassificationReaderTest extends ModsReaderTest
     {
         $classifications = $this->bookReader->getClassifications('[@authority="ddc"]');
         self::assertNotEmpty($classifications);
-        self::assertEquals(1, count($classifications));
+        self::assertCount(1, $classifications);
         self::assertSecondClassificationForBookDocument($classifications[0]);
     }
 
@@ -116,7 +116,7 @@ class ClassificationReaderTest extends ModsReaderTest
     {
         $classifications = $this->serialReader->getClassifications();
         self::assertNotEmpty($classifications);
-        self::assertEquals(1, count($classifications));
+        self::assertCount(1, $classifications);
         self::assertClassificationForSerialDocument($classifications[0]);
     }
 
@@ -127,7 +127,7 @@ class ClassificationReaderTest extends ModsReaderTest
     {
         $classifications = $this->serialReader->getClassifications('[@authority="ddc"]');
         self::assertNotEmpty($classifications);
-        self::assertEquals(1, count($classifications));
+        self::assertCount(1, $classifications);
         self::assertClassificationForSerialDocument($classifications[0]);
     }
 

--- a/tests/Mods/Reader/GenreReaderTest.php
+++ b/tests/Mods/Reader/GenreReaderTest.php
@@ -28,7 +28,7 @@ class GenreReaderTest extends ModsReaderTest
     {
         $genres = $this->bookReader->getGenres();
         self::assertNotEmpty($genres);
-        self::assertEquals(1, count($genres));
+        self::assertCount(1, $genres);
         self::assertGenreForBookDocument($genres[0]);
     }
 
@@ -66,7 +66,7 @@ class GenreReaderTest extends ModsReaderTest
     {
         $genres = $this->bookReader->getGenres('[@authority="marcgt"]');
         self::assertNotEmpty($genres);
-        self::assertEquals(1, count($genres));
+        self::assertCount(1, $genres);
         self::assertGenreForBookDocument($genres[0]);
     }
 
@@ -140,7 +140,7 @@ class GenreReaderTest extends ModsReaderTest
     {
         $genres = $this->serialReader->getGenres();
         self::assertNotEmpty($genres);
-        self::assertEquals(2, count($genres));
+        self::assertCount(2, $genres);
         self::assertFirstGenreForSerialDocument($genres[0]);
     }
 
@@ -178,7 +178,7 @@ class GenreReaderTest extends ModsReaderTest
     {
         $genres = $this->serialReader->getGenres('[@usage="primary"]');
         self::assertNotEmpty($genres);
-        self::assertEquals(1, count($genres));
+        self::assertCount(1, $genres);
         self::assertFirstGenreForSerialDocument($genres[0]);
     }
 

--- a/tests/Mods/Reader/IdentifierReaderTest.php
+++ b/tests/Mods/Reader/IdentifierReaderTest.php
@@ -28,7 +28,7 @@ class IdentifierReaderTest extends ModsReaderTest
     {
         $identifiers = $this->bookReader->getIdentifiers();
         self::assertNotEmpty($identifiers);
-        self::assertEquals(2, count($identifiers));
+        self::assertCount(2, $identifiers);
         self::assertFirstIdentifierForBookDocument($identifiers[0]);
     }
 
@@ -66,7 +66,7 @@ class IdentifierReaderTest extends ModsReaderTest
     {
         $identifiers = $this->bookReader->getIdentifiers('[@type="lccn"]');
         self::assertNotEmpty($identifiers);
-        self::assertEquals(1, count($identifiers));
+        self::assertCount(1, $identifiers);
         self::assertSecondIdentifierForBookDocument($identifiers[0]);
     }
 
@@ -140,7 +140,7 @@ class IdentifierReaderTest extends ModsReaderTest
     {
         $identifiers = $this->serialReader->getIdentifiers();
         self::assertNotEmpty($identifiers);
-        self::assertEquals(4, count($identifiers));
+        self::assertCount(4, $identifiers);
         self::assertFirstIdentifierForSerialDocument($identifiers[0]);
     }
 
@@ -178,7 +178,7 @@ class IdentifierReaderTest extends ModsReaderTest
     {
         $identifiers = $this->serialReader->getIdentifiers('[@type="issn"]');
         self::assertNotEmpty($identifiers);
-        self::assertEquals(2, count($identifiers));
+        self::assertCount(2, $identifiers);
         self::assertSecondIdentifierForSerialDocument($identifiers[1]);
     }
 

--- a/tests/Mods/Reader/LanguageReaderTest.php
+++ b/tests/Mods/Reader/LanguageReaderTest.php
@@ -28,7 +28,7 @@ class LanguageReaderTest extends ModsReaderTest
     {
         $languages = $this->bookReader->getLanguages();
         self::assertNotEmpty($languages);
-        self::assertEquals(2, count($languages));
+        self::assertCount(2, $languages);
         self::assertFirstLanguageForBookDocument($languages[0]);
     }
 
@@ -66,7 +66,7 @@ class LanguageReaderTest extends ModsReaderTest
     {
         $languages = $this->bookReader->getLanguages('[@objectPart="summary"]');
         self::assertNotEmpty($languages);
-        self::assertEquals(1, count($languages));
+        self::assertCount(1, $languages);
         self::assertSecondLanguageForBookDocument($languages[0]);
     }
 
@@ -140,7 +140,7 @@ class LanguageReaderTest extends ModsReaderTest
     {
         $languages = $this->serialReader->getLanguages();
         self::assertNotEmpty($languages);
-        self::assertEquals(1, count($languages));
+        self::assertCount(1, $languages);
         self::assertLanguageForSerialDocument($languages[0]);
     }
 
@@ -151,7 +151,7 @@ class LanguageReaderTest extends ModsReaderTest
     {
         $languages = $this->serialReader->getLanguages('[./mods:languageTerm[@type="code"]]');
         self::assertNotEmpty($languages);
-        self::assertEquals(1, count($languages));
+        self::assertCount(1, $languages);
         self::assertLanguageForSerialDocument($languages[0]);
     }
 

--- a/tests/Mods/Reader/LocationReaderTest.php
+++ b/tests/Mods/Reader/LocationReaderTest.php
@@ -29,7 +29,7 @@ class LocationReaderTest extends ModsReaderTest
     {
         $locations = $this->bookReader->getLocations();
         self::assertNotEmpty($locations);
-        self::assertEquals(2, count($locations));
+        self::assertCount(2, $locations);
         self::assertFirstLocationForBookDocument($locations[0]);
     }
 
@@ -67,7 +67,7 @@ class LocationReaderTest extends ModsReaderTest
     {
         $locations = $this->bookReader->getLocations('[@displayLabel="links"]');
         self::assertNotEmpty($locations);
-        self::assertEquals(1, count($locations));
+        self::assertCount(1, $locations);
         self::assertSecondLocationForBookDocument($locations[0]);
 
         $this->expectException(IncorrectValueInAttributeException::class);
@@ -144,7 +144,7 @@ class LocationReaderTest extends ModsReaderTest
     {
         $locations = $this->serialReader->getLocations();
         self::assertNotEmpty($locations);
-        self::assertEquals(2, count($locations));
+        self::assertCount(2, $locations);
         self::assertLocationForSerialDocument($locations[0]);
     }
 
@@ -155,7 +155,7 @@ class LocationReaderTest extends ModsReaderTest
     {
         $locations = $this->serialReader->getLocations('[./mods:url[@usage="primaryDisplay"]]');
         self::assertNotEmpty($locations);
-        self::assertEquals(1, count($locations));
+        self::assertCount(1, $locations);
         self::assertLocationForSerialDocument($locations[0]);
     }
 
@@ -196,7 +196,7 @@ class LocationReaderTest extends ModsReaderTest
 
         $urls = $location->getUrls();
         self::assertNotEmpty($urls);
-        self::assertEquals(4, count($urls));
+        self::assertCount(4, $urls);
         self::assertEquals('2024-01-27', $urls[0]->getDateLastAccessed());
         self::assertEquals('http://www.slub-dresden.de/some-url', $urls[0]->getValue());
         self::assertEquals('preview', $urls[1]->getAccess());

--- a/tests/Mods/Reader/NameReaderTest.php
+++ b/tests/Mods/Reader/NameReaderTest.php
@@ -28,7 +28,7 @@ class NameReaderTest extends ModsReaderTest
     {
         $names = $this->bookReader->getNames();
         self::assertNotEmpty($names);
-        self::assertEquals(2, count($names));
+        self::assertCount(2, $names);
         self::assertFirstNameForBookDocument($names[0]);
     }
 
@@ -66,7 +66,7 @@ class NameReaderTest extends ModsReaderTest
     {
         $names = $this->bookReader->getNames('[@type="personal" and not(@usage="primary")]');
         self::assertNotEmpty($names);
-        self::assertEquals(1, count($names));
+        self::assertCount(1, $names);
         self::assertSecondNameForBookDocument($names[0]);
     }
 
@@ -140,7 +140,7 @@ class NameReaderTest extends ModsReaderTest
     {
         $names = $this->serialReader->getNames();
         self::assertNotEmpty($names);
-        self::assertEquals(1, count($names));
+        self::assertCount(1, $names);
         self::assertNameForSerialDocument($names[0]);
     }
 
@@ -151,7 +151,7 @@ class NameReaderTest extends ModsReaderTest
     {
         $names = $this->serialReader->getNames('[@type="corporate"]');
         self::assertNotEmpty($names);
-        self::assertEquals(1, count($names));
+        self::assertCount(1, $names);
         self::assertNameForSerialDocument($names[0]);
     }
 
@@ -194,8 +194,8 @@ class NameReaderTest extends ModsReaderTest
         self::assertNotEmpty($name->getValue());
 
         $nameParts = $name->getNameParts();
-        self::assertNotEmpty($name->getNameParts());
-        self::assertEquals(2, count($nameParts));
+        self::assertNotEmpty($nameParts);
+        self::assertCount(2, $nameParts);
         self::assertEquals('given', $nameParts[0]->getType());
         self::assertEquals('Aron', $nameParts[0]->getValue());
 
@@ -214,8 +214,8 @@ class NameReaderTest extends ModsReaderTest
         self::assertNotEmpty($name->getValue());
 
         $nameParts = $name->getNameParts();
-        self::assertNotEmpty($name->getNameParts());
-        self::assertEquals(1, count($nameParts));
+        self::assertNotEmpty($nameParts);
+        self::assertCount(1, $nameParts);
         self::assertEquals('International Consortium for the Advancement of Academic Publication.', $nameParts[0]->getValue());
     }
 }

--- a/tests/Mods/Reader/NoteReaderTest.php
+++ b/tests/Mods/Reader/NoteReaderTest.php
@@ -28,7 +28,7 @@ class NoteReaderTest extends ModsReaderTest
     {
         $notes = $this->bookReader->getNotes();
         self::assertNotEmpty($notes);
-        self::assertEquals(2, count($notes));
+        self::assertCount(2, $notes);
         self::assertFirstNoteForBookDocument($notes[0]);
     }
 
@@ -66,7 +66,7 @@ class NoteReaderTest extends ModsReaderTest
     {
         $notes = $this->bookReader->getNotes('[@type="bibliography"]');
         self::assertNotEmpty($notes);
-        self::assertEquals(1, count($notes));
+        self::assertCount(1, $notes);
         self::assertSecondNoteForBookDocument($notes[0]);
     }
 
@@ -140,7 +140,7 @@ class NoteReaderTest extends ModsReaderTest
     {
         $notes = $this->serialReader->getNotes();
         self::assertNotEmpty($notes);
-        self::assertEquals(6, count($notes));
+        self::assertCount(6, $notes);
         self::assertFirstNoteForSerialDocument($notes[0]);
     }
 
@@ -178,7 +178,7 @@ class NoteReaderTest extends ModsReaderTest
     {
         $notes = $this->serialReader->getNotes('[@type="system details"]');
         self::assertNotEmpty($notes);
-        self::assertEquals(1, count($notes));
+        self::assertCount(1, $notes);
         self::assertFifthNoteForSerialDocument($notes[0]);
     }
 

--- a/tests/Mods/Reader/OriginInfoReaderTest.php
+++ b/tests/Mods/Reader/OriginInfoReaderTest.php
@@ -28,7 +28,7 @@ class OriginInfoReaderTest extends ModsReaderTest
     {
         $originInfos = $this->bookReader->getOriginInfos();
         self::assertNotEmpty($originInfos);
-        self::assertEquals(2, count($originInfos));
+        self::assertCount(2, $originInfos);
         self::assertFirstOriginInfoForBookDocument($originInfos[0]);
     }
 
@@ -66,7 +66,7 @@ class OriginInfoReaderTest extends ModsReaderTest
     {
         $originInfos = $this->bookReader->getOriginInfos('[@eventType="redaction"]');
         self::assertNotEmpty($originInfos);
-        self::assertEquals(1, count($originInfos));
+        self::assertCount(1, $originInfos);
         self::assertSecondOriginInfoForBookDocument($originInfos[0]);
     }
 
@@ -119,7 +119,7 @@ class OriginInfoReaderTest extends ModsReaderTest
     {
         $originInfos = $this->serialReader->getOriginInfos();
         self::assertNotEmpty($originInfos);
-        self::assertEquals(1, count($originInfos));
+        self::assertCount(1, $originInfos);
         self::assertOriginInfoForSerialDocument($originInfos[0]);
     }
 
@@ -130,7 +130,7 @@ class OriginInfoReaderTest extends ModsReaderTest
     {
         $originInfos = $this->serialReader->getOriginInfos('[@eventType="publication"]');
         self::assertNotEmpty($originInfos);
-        self::assertEquals(1, count($originInfos));
+        self::assertCount(1, $originInfos);
         self::assertOriginInfoForSerialDocument($originInfos[0]);
     }
 
@@ -151,7 +151,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $places = $originInfo->getPlaces();
         self::assertNotEmpty($places);
-        self::assertEquals(2, count($places));
+        self::assertCount(2, $places);
 
         $placeTerms = $places[0]->getPlaceTerms();
         self::assertNotEmpty($placeTerms);
@@ -161,7 +161,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $issuedDates = $originInfo->getIssuedDates();
         self::assertNotEmpty($issuedDates);
-        self::assertEquals(2, count($issuedDates));
+        self::assertCount(2, $issuedDates);
         self::assertEquals('marc', $issuedDates[0]->getEncoding());
         self::assertEquals('2000', $issuedDates[0]->getValue());
 
@@ -178,7 +178,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $places = $originInfo->getPlaces();
         self::assertNotEmpty($places);
-        self::assertEquals(2, count($places));
+        self::assertCount(2, $places);
 
         $placeTerms = $places[1]->getPlaceTerms();
         self::assertNotEmpty($placeTerms);
@@ -187,7 +187,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $issuedDates = $originInfo->getIssuedDates();
         self::assertNotEmpty($issuedDates);
-        self::assertEquals(2, count($issuedDates));
+        self::assertCount(2, $issuedDates);
         self::assertEquals('marc', $issuedDates[0]->getEncoding());
         self::assertEquals('1999', $issuedDates[0]->getValue());
 
@@ -202,7 +202,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $places = $originInfo->getPlaces();
         self::assertNotEmpty($places);
-        self::assertEquals(2, count($places));
+        self::assertCount(2, $places);
 
         $placeTerms = $places[0]->getPlaceTerms();
         self::assertNotEmpty($placeTerms);
@@ -212,7 +212,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $issuedDates = $originInfo->getIssuedDates();
         self::assertNotEmpty($issuedDates);
-        self::assertEquals(3, count($issuedDates));
+        self::assertCount(3, $issuedDates);
         self::assertEquals('marc', $issuedDates[0]->getEncoding());
         self::assertEquals('start', $issuedDates[0]->getPoint());
         self::assertEquals('2002', $issuedDates[0]->getValue());
@@ -223,7 +223,7 @@ class OriginInfoReaderTest extends ModsReaderTest
 
         $frequencies = $originInfo->getFrequencies();
         self::assertNotEmpty($frequencies);
-        self::assertEquals(2, count($frequencies));
+        self::assertCount(2, $frequencies);
         self::assertEquals('Three times a year', $frequencies[0]->getValue());
 
         $agents = $originInfo->getAgents();

--- a/tests/Mods/Reader/PartReaderTest.php
+++ b/tests/Mods/Reader/PartReaderTest.php
@@ -28,7 +28,7 @@ class PartReaderTest extends ModsReaderTest
     {
         $parts = $this->bookReader->getParts();
         self::assertNotEmpty($parts);
-        self::assertEquals(2, count($parts));
+        self::assertCount(2, $parts);
         self::assertFirstPartForBookDocument($parts[0]);
     }
 
@@ -66,7 +66,7 @@ class PartReaderTest extends ModsReaderTest
     {
         $parts = $this->bookReader->getParts('[@order="2"]');
         self::assertNotEmpty($parts);
-        self::assertEquals(1, count($parts));
+        self::assertCount(1, $parts);
         self::assertSecondPartForBookDocument($parts[0]);
     }
 
@@ -156,7 +156,7 @@ class PartReaderTest extends ModsReaderTest
 
         $details = $part->getDetails();
         self::assertNotEmpty($details);
-        self::assertEquals(2, count($details));
+        self::assertCount(2, $details);
         self::assertEquals('begin', $details[0]->getType());
         self::assertEquals(1, $details[0]->getLevel());
         self::assertNotEmpty($details[0]->getTitles());

--- a/tests/Mods/Reader/PhysicalDescriptionReaderTest.php
+++ b/tests/Mods/Reader/PhysicalDescriptionReaderTest.php
@@ -28,7 +28,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
     {
         $physicalDescriptions = $this->bookReader->getPhysicalDescriptions();
         self::assertNotEmpty($physicalDescriptions);
-        self::assertEquals(1, count($physicalDescriptions));
+        self::assertCount(1, $physicalDescriptions);
         self::assertPhysicalDescriptionForBookDocument($physicalDescriptions[0]);
     }
 
@@ -77,7 +77,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
     {
         $physicalDescriptions = $this->bookReader->getPhysicalDescriptions('[./mods:form[@authority="marcform"]="print"]');
         self::assertNotEmpty($physicalDescriptions);
-        self::assertEquals(1, count($physicalDescriptions));
+        self::assertCount(1, $physicalDescriptions);
         self::assertPhysicalDescriptionForBookDocument($physicalDescriptions[0]);
     }
 
@@ -124,7 +124,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
     {
         $physicalDescriptions = $this->serialReader->getPhysicalDescriptions();
         self::assertNotEmpty($physicalDescriptions);
-        self::assertEquals(1, count($physicalDescriptions));
+        self::assertCount(1, $physicalDescriptions);
         self::assertPhysicalDescriptionForSerialDocument($physicalDescriptions[0]);
     }
 
@@ -135,7 +135,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
     {
         $physicalDescriptions = $this->serialReader->getPhysicalDescriptions('[./mods:form[@authority="marcform"]="electronic"]');
         self::assertNotEmpty($physicalDescriptions);
-        self::assertEquals(1, count($physicalDescriptions));
+        self::assertCount(1, $physicalDescriptions);
         self::assertPhysicalDescriptionForSerialDocument($physicalDescriptions[0]);
     }
 
@@ -171,7 +171,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
         self::assertNotEmpty($physicalDescription->getForms());
 
         $forms = $physicalDescription->getForms();
-        self::assertEquals(2, count($forms));
+        self::assertCount(2, $forms);
         self::assertEquals('gmd', $forms[1]->getAuthority());
         self::assertEquals('electronic resource', $forms[1]->getValue());
         self::assertNotEmpty($physicalDescription->getInternetMediaTypes());

--- a/tests/Mods/Reader/RecordInfoReaderTest.php
+++ b/tests/Mods/Reader/RecordInfoReaderTest.php
@@ -26,7 +26,7 @@ class RecordInfoReaderTest extends ModsReaderTest
     {
         $recordInfos = $this->bookReader->getRecordInfos();
         self::assertNotEmpty($recordInfos);
-        self::assertEquals(1, count($recordInfos));
+        self::assertCount(1, $recordInfos);
         self::assertRecordInfoForBookDocument($recordInfos[0]);
     }
 
@@ -52,7 +52,7 @@ class RecordInfoReaderTest extends ModsReaderTest
     {
         $recordInfos = $this->bookReader->getRecordInfos('[./mods:descriptionStandard="aacr"]');
         self::assertNotEmpty($recordInfos);
-        self::assertEquals(1, count($recordInfos));
+        self::assertCount(1, $recordInfos);
         self::assertRecordInfoForBookDocument($recordInfos[0]);
     }
 
@@ -96,7 +96,7 @@ class RecordInfoReaderTest extends ModsReaderTest
     {
         $recordInfos = $this->serialReader->getRecordInfos();
         self::assertNotEmpty($recordInfos);
-        self::assertEquals(1, count($recordInfos));
+        self::assertCount(1, $recordInfos);
         self::assertRecordInfoForSerialDocument($recordInfos[0]);
 
         $this->expectException(IncorrectValueInAttributeException::class);
@@ -107,7 +107,7 @@ class RecordInfoReaderTest extends ModsReaderTest
     {
         $recordInfos = $this->serialReader->getRecordInfos('[./mods:descriptionStandard="aacr"]');
         self::assertNotEmpty($recordInfos);
-        self::assertEquals(1, count($recordInfos));
+        self::assertCount(1, $recordInfos);
         self::assertRecordInfoForSerialDocument($recordInfos[0]);
 
         $this->expectException(IncorrectValueInAttributeException::class);
@@ -175,7 +175,7 @@ class RecordInfoReaderTest extends ModsReaderTest
 
         $recordInfoNotes = $recordInfo->getRecordInfoNotes();
         self::assertNotEmpty($recordInfo->getRecordInfoNotes());
-        self::assertEquals(2, count($recordInfoNotes));
+        self::assertCount(2, $recordInfoNotes);
         self::assertEquals('Some info', $recordInfoNotes[1]->getValue());
 
         $languages = $recordInfo->getLanguageOfCatalogings();

--- a/tests/Mods/Reader/RelatedItemReaderTest.php
+++ b/tests/Mods/Reader/RelatedItemReaderTest.php
@@ -64,7 +64,7 @@ class RelatedItemReaderTest extends ModsReaderTest
     {
         $relatedItems = $this->serialReader->getRelatedItems();
         self::assertNotEmpty($relatedItems);
-        self::assertEquals(1, count($relatedItems));
+        self::assertCount(1, $relatedItems);
         self::assertRelatedItemForSerialDocument($relatedItems[0]);
     }
 
@@ -102,7 +102,7 @@ class RelatedItemReaderTest extends ModsReaderTest
     {
         $relatedItems = $this->serialReader->getRelatedItems('[./mods:identifier="1525-321X"]');
         self::assertNotEmpty($relatedItems);
-        self::assertEquals(1, count($relatedItems));
+        self::assertCount(1, $relatedItems);
         self::assertRelatedItemForSerialDocument($relatedItems[0]);
     }
 
@@ -125,12 +125,12 @@ class RelatedItemReaderTest extends ModsReaderTest
         // TODO: implement back compatibility for 'publisher' element
         // self::assertEquals('Journal of southern academic and special librarianship', $relatedItem->getOriginInfos()[0]->getPublisher());
         self::assertNotEmpty($relatedItem->getIdentifiers());
-        self::assertEquals(4, count($relatedItem->getIdentifiers()));
+        self::assertCount(4, $relatedItem->getIdentifiers());
         self::assertEquals('1525-321X', $relatedItem->getIdentifiers()[0]->getValue());
 
         $localIdentifiers = $relatedItem->getIdentifiers('[@type="local"]');
         self::assertNotEmpty($localIdentifiers);
-        self::assertEquals(3, count($localIdentifiers));
+        self::assertCount(3, $localIdentifiers);
         self::assertEquals('(OCoLC)41477508', $localIdentifiers[0]->getValue());
     }
 }

--- a/tests/Mods/Reader/SubjectReaderTest.php
+++ b/tests/Mods/Reader/SubjectReaderTest.php
@@ -28,7 +28,7 @@ class SubjectReaderTest extends ModsReaderTest
     {
         $subjects = $this->bookReader->getSubjects();
         self::assertNotEmpty($subjects);
-        self::assertEquals(8, count($subjects));
+        self::assertCount(8, $subjects);
         self::assertFirstSubjectForBookDocument($subjects[0]);
     }
 
@@ -66,7 +66,7 @@ class SubjectReaderTest extends ModsReaderTest
     {
         $subjects = $this->bookReader->getSubjects('[./mods:topic="Mass media"]');
         self::assertNotEmpty($subjects);
-        self::assertEquals(1, count($subjects));
+        self::assertCount(1, $subjects);
         self::assertFourthSubjectForBookDocument($subjects[0]);
     }
 
@@ -140,7 +140,7 @@ class SubjectReaderTest extends ModsReaderTest
     {
         $subjects = $this->serialReader->getSubjects();
         self::assertNotEmpty($subjects);
-        self::assertEquals(7, count($subjects));
+        self::assertCount(7, $subjects);
         self::assertNotEmpty($subjects[0]->getValue());
         self::assertNotEmpty($subjects[0]->getCartographics());
 
@@ -160,7 +160,7 @@ class SubjectReaderTest extends ModsReaderTest
     {
         $subjects = $this->serialReader->getSubjects('[./mods:genre="Directories"]');
         self::assertNotEmpty($subjects);
-        self::assertEquals(1, count($subjects));
+        self::assertCount(1, $subjects);
         self::assertNotEmpty($subjects[0]->getValue());
         self::assertNotEmpty($subjects[0]->getTopics());
         self::assertEquals('Web sites', $subjects[0]->getTopics()[0]->getValue());
@@ -186,7 +186,7 @@ class SubjectReaderTest extends ModsReaderTest
 
         $countries = $hierarchicalGeographics[0]->getCountries();
         self::assertNotEmpty($countries);
-        self::assertEquals(2, count($countries));
+        self::assertCount(2, $countries);
         self::assertEquals(1, $countries[0]->getLevel());
         self::assertEquals('United Kingdom', $countries[0]->getValue());
         self::assertNotEmpty($hierarchicalGeographics[0]->getRegions());
@@ -198,13 +198,14 @@ class SubjectReaderTest extends ModsReaderTest
 
         $citySections = $hierarchicalGeographics[0]->getCitySections();
         self::assertNotEmpty($citySections);
-        self::assertEquals(2, count($citySections));
+        self::assertCount(2, $citySections);
         self::assertEquals('neighborhood', $citySections[0]->getType());
         self::assertEquals(1, $citySections[0]->getLevel());
         self::assertEquals('East Side', $citySections[0]->getValue());
 
         $areas = $hierarchicalGeographics[0]->getAreas();
         self::assertNotEmpty($areas);
+        self::assertCount(1, $areas);
         self::assertEquals('national park', $areas[0]->getType());
         self::assertEquals('Lake District', $areas[0]->getValue());
     }

--- a/tests/Mods/Reader/TableOfContentsReaderTest.php
+++ b/tests/Mods/Reader/TableOfContentsReaderTest.php
@@ -28,7 +28,7 @@ class TableOfContentsReaderTest extends ModsReaderTest
     {
         $tablesOfContents = $this->bookReader->getTablesOfContents();
         self::assertNotEmpty($tablesOfContents);
-        self::assertEquals(1, count($tablesOfContents));
+        self::assertCount(1, $tablesOfContents);
         self::assertTableOfContentsForBookDocument($tablesOfContents[0]);
     }
 
@@ -66,7 +66,7 @@ class TableOfContentsReaderTest extends ModsReaderTest
     {
         $tablesOfContents = $this->bookReader->getTablesOfContents('[@displayLabel="Chapters"]');
         self::assertNotEmpty($tablesOfContents);
-        self::assertEquals(1, count($tablesOfContents));
+        self::assertCount(1, $tablesOfContents);
         self::assertTableOfContentsForBookDocument($tablesOfContents[0]);
     }
 

--- a/tests/Mods/Reader/TitleInfoReaderTest.php
+++ b/tests/Mods/Reader/TitleInfoReaderTest.php
@@ -27,7 +27,7 @@ class TitleInfoReaderTest extends ModsReaderTest
     {
         $titleInfos = $this->bookReader->getTitleInfos();
         self::assertNotEmpty($titleInfos);
-        self::assertEquals(2, count($titleInfos));
+        self::assertCount(2, $titleInfos);
         self::assertNotEmpty($titleInfos[0]->getValue());
         self::assertEquals('Sound and fury', $titleInfos[0]->getTitle()->getValue());
         self::assertEquals('the making of the punditocracy', $titleInfos[0]->getSubTitle()->getValue());
@@ -40,7 +40,7 @@ class TitleInfoReaderTest extends ModsReaderTest
     {
         $titleInfos = $this->bookReader->getTitleInfos('[@xml:lang="fr"]');
         self::assertNotEmpty($titleInfos);
-        self::assertEquals(1, count($titleInfos));
+        self::assertCount(1, $titleInfos);
         self::assertNotEmpty($titleInfos[0]->getValue());
         self::assertNotEmpty($titleInfos[0]->getType());
         self::assertEquals('translated', $titleInfos[0]->getType());
@@ -59,7 +59,7 @@ class TitleInfoReaderTest extends ModsReaderTest
     {
         $titleInfos = $this->serialReader->getTitleInfos();
         self::assertNotEmpty($titleInfos);
-        self::assertEquals(3, count($titleInfos));
+        self::assertCount(3, $titleInfos);
         self::assertNotEmpty($titleInfos[0]->getValue());
         self::assertNotEmpty($titleInfos[0]->getTitle());
         self::assertEquals('E-JASL', $titleInfos[0]->getTitle()->getValue());
@@ -74,7 +74,7 @@ class TitleInfoReaderTest extends ModsReaderTest
     {
         $titleInfos = $this->serialReader->getTitleInfos('[@type="abbreviated"]');
         self::assertNotEmpty($titleInfos);
-        self::assertEquals(1, count($titleInfos));
+        self::assertCount(1, $titleInfos);
         self::assertNotEmpty($titleInfos[0]->getValue());
         self::assertEquals('E-JASL', $titleInfos[0]->getTitle()->getValue());
         self::assertNotEmpty($titleInfos[0]->getSubTitle());


### PR DESCRIPTION
Switches from `assertEquals(X, count($var))` to `assertCount(X, $var)` for checking collection sizes across various test files. This enhances readability and utilizes the more semantically correct PHPUnit assertion.