### PR TITLE
[MAINTENANCE] Raise minimum PHP version and update dev tools

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variants: [{ php: 7.4 }, { php: 8.2 }, { php: 8.4 } ]
+        variants: [ { php: 8.2 }, { php: 8.4 } ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,17 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-    - uses: php-actions/composer@v6
+    - name: Install dependencies
+      uses: php-actions/composer@v6
 
-    - name: Tests
-      uses: php-actions/phpunit@v3
+    - name: Run tests
+      uses: php-actions/phpunit@v4
       env:
         TEST_NAME: Scarlett
       with:
         bootstrap: vendor/autoload.php
         configuration: phpunit.xml
         args: --coverage-text
-        version: 9
-        php_version: "7.4"
+        version: 11
+        php_version: "8.2"

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "mods-reader"
     ],
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.2"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.12",
-        "phpunit/phpunit": "~9.6"
+        "phpstan/phpstan": "^2.2",
+        "phpunit/phpunit": "^11.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="../vendor/phpunit/tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         shortenArraysForExportThreshold="10"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="false"
+         failOnPhpunitWarning="false"
+         failOnRisky="true"
+         failOnWarning="false"
+         colors="true">
     <testsuites>
         <testsuite name="MODS Reader Test Suite">
             <directory>./tests/Mods/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+    <php>
+        <ini name="precision" value="14"/>
+        <ini name="serialize_precision" value="14"/>
+
+        <const name="PHPUNIT_TESTSUITE" value="true"/>
+    </php>
 </phpunit>

--- a/tests/Mods/Reader/AbstractReaderTest.php
+++ b/tests/Mods/Reader/AbstractReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\ModsReaderTest;
 
 /**
@@ -20,9 +21,7 @@ use Slub\Mods\ModsReaderTest;
 class AbstractReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAbstractForBookDocument()
     {
         $abstract = $this->bookReader->getAbstract();
@@ -34,9 +33,7 @@ class AbstractReaderTest extends ModsReaderTest
         self::assertTrue($abstract->isShareable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAbstractByQueryForBookDocument()
     {
         $abstract = $this->bookReader->getAbstract('[@displayLabel="Content description"]');
@@ -48,18 +45,14 @@ class AbstractReaderTest extends ModsReaderTest
         self::assertTrue($abstract->isShareable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoAbstractByQueryForBookDocument()
     {
         $abstract = $this->bookReader->getAbstract('[@displayLabel="Random"]');
         self::assertNull($abstract);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAbstractForSerialDocument()
     {
         $abstract = $this->serialReader->getAbstract();
@@ -70,9 +63,7 @@ class AbstractReaderTest extends ModsReaderTest
         self::assertFalse($abstract->isShareable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAbstractByQueryForSerialDocument()
     {
         $abstract = $this->serialReader->getAbstract('[@shareable="no"]');
@@ -83,9 +74,7 @@ class AbstractReaderTest extends ModsReaderTest
         self::assertFalse($abstract->isShareable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoAbstractByQueryForSerialDocument()
     {
         $abstract = $this->serialReader->getAbstract('[@shareable="yes"]');

--- a/tests/Mods/Reader/AccessConditionReaderTest.php
+++ b/tests/Mods/Reader/AccessConditionReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\AccessCondition;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class AccessConditionReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAccessConditionsForBookDocument()
     {
         $accessConditions = $this->bookReader->getAccessConditions();
@@ -32,36 +31,28 @@ class AccessConditionReaderTest extends ModsReaderTest
         self::assertAccessConditionForBookDocument($accessConditions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAccessConditionForBookDocument()
     {
         $accessCondition = $this->bookReader->getAccessCondition(0);
         self::assertAccessConditionForBookDocument($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstAccessConditionForBookDocument()
     {
         $accessCondition = $this->bookReader->getFirstAccessCondition();
         self::assertAccessConditionForBookDocument($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastAccessConditionForBookDocument()
     {
         $accessCondition = $this->bookReader->getLastAccessCondition();
         self::assertAccessConditionForBookDocument($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAccessConditionsByQueryForBookDocument()
     {
         $accessConditions = $this->bookReader->getAccessConditions('[@type="use and reproduction"]');
@@ -70,63 +61,49 @@ class AccessConditionReaderTest extends ModsReaderTest
         self::assertAccessConditionForBookDocument($accessConditions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstAccessConditionByQueryForBookDocument()
     {
         $accessCondition = $this->bookReader->getFirstAccessCondition('[@type="use and reproduction"]');
         self::assertAccessConditionForBookDocument($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastAccessConditionByQueryForBookDocument()
     {
         $accessCondition = $this->bookReader->getLastAccessCondition('[@type="use and reproduction"]');
         self::assertAccessConditionForBookDocument($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoAccessConditionsByQueryForBookDocument()
     {
         $accessConditions = $this->bookReader->getAccessConditions('[@type="restriction on access"]');
         self::assertEmpty($accessConditions);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoAccessConditionByQueryForBookDocument()
     {
         $accessCondition = $this->bookReader->getAccessCondition(1, '[@type="restriction on access"]');
         self::assertNull($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstAccessConditionsByQueryForBookDocument()
     {
         $accessCondition = $this->bookReader->getFirstAccessCondition('[@type="restriction on access"]');
         self::assertNull($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastAccessConditionsByQueryForBookDocument()
     {
         $accessCondition = $this->bookReader->getLastAccessCondition('[@type="restriction on access"]');
         self::assertNull($accessCondition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAccessConditionsForSerialDocument()
     {
         $accessConditions = $this->serialReader->getAccessConditions();
@@ -135,9 +112,7 @@ class AccessConditionReaderTest extends ModsReaderTest
         self::assertAccessConditionForSerialDocument($accessConditions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAccessConditionsByQueryForSerialDocument()
     {
         $accessConditions = $this->serialReader->getAccessConditions('[@type="restriction on access"]');
@@ -146,9 +121,7 @@ class AccessConditionReaderTest extends ModsReaderTest
         self::assertAccessConditionForSerialDocument($accessConditions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoAccessConditionsByQueryForSerialDocument()
     {
         $accessConditions = $this->serialReader->getAccessConditions('[@type="use and reproduction"]');

--- a/tests/Mods/Reader/ClassificationReaderTest.php
+++ b/tests/Mods/Reader/ClassificationReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Classification;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class ClassificationReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getClassificationsForBookDocument()
     {
         $classifications = $this->bookReader->getClassifications();
@@ -32,36 +31,28 @@ class ClassificationReaderTest extends ModsReaderTest
         self::assertFirstClassificationForBookDocument($classifications[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getClassificationForBookDocument()
     {
         $classification = $this->bookReader->getClassification(0);
         self::assertFirstClassificationForBookDocument($classification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstClassificationForBookDocument()
     {
         $classification = $this->bookReader->getFirstClassification();
         self::assertFirstClassificationForBookDocument($classification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastClassificationForBookDocument()
     {
         $classification = $this->bookReader->getLastClassification();
         self::assertSecondClassificationForBookDocument($classification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getClassificationsByQueryForBookDocument()
     {
         $classifications = $this->bookReader->getClassifications('[@authority="ddc"]');
@@ -70,27 +61,21 @@ class ClassificationReaderTest extends ModsReaderTest
         self::assertSecondClassificationForBookDocument($classifications[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoClassificationsByQueryForBookDocument()
     {
         $classifications = $this->bookReader->getClassifications('[@generator="xyz"]');
         self::assertEmpty($classifications);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoClassificationByQueryForBookDocument()
     {
         $classification = $this->bookReader->getClassification(1, '[@generator="xyz"]');
         self::assertNull($classification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstClassificationByQueryForBookDocument()
     {
         $classification = $this->bookReader->getFirstClassification('[@generator="xyz"]');
@@ -100,18 +85,14 @@ class ClassificationReaderTest extends ModsReaderTest
         self::assertNull($lastClassification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastClassificationByQueryForBookDocument()
     {
         $classification = $this->bookReader->getLastClassification('[@generator="xyz"]');
         self::assertNull($classification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getClassificationsForSerialDocument()
     {
         $classifications = $this->serialReader->getClassifications();
@@ -120,9 +101,7 @@ class ClassificationReaderTest extends ModsReaderTest
         self::assertClassificationForSerialDocument($classifications[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getClassificationsByQueryForSerialDocument()
     {
         $classifications = $this->serialReader->getClassifications('[@authority="ddc"]');
@@ -131,9 +110,7 @@ class ClassificationReaderTest extends ModsReaderTest
         self::assertClassificationForSerialDocument($classifications[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoClassificationsByQueryForSerialDocument()
     {
         $classifications = $this->serialReader->getClassifications('[@edition="22"]');

--- a/tests/Mods/Reader/ExtensionReaderTest.php
+++ b/tests/Mods/Reader/ExtensionReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\ModsReaderTest;
 
 /**
@@ -20,18 +21,14 @@ use Slub\Mods\ModsReaderTest;
 class ExtensionReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getExtensionsForBookDocument()
     {
         // $extensions = $this->bookReader->getExtensions();
         $this->assertTrue(true, 'WIP');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getExtensionsForSerialDocument()
     {
         // $extensions = $this->serialReader->getExtensions();

--- a/tests/Mods/Reader/GenreReaderTest.php
+++ b/tests/Mods/Reader/GenreReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Genre;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class GenreReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenresForBookDocument()
     {
         $genres = $this->bookReader->getGenres();
@@ -32,36 +31,28 @@ class GenreReaderTest extends ModsReaderTest
         self::assertGenreForBookDocument($genres[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenreForBookDocument()
     {
         $genre = $this->bookReader->getGenre(0);
         self::assertGenreForBookDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstGenreForBookDocument()
     {
         $genre = $this->bookReader->getFirstGenre();
         self::assertGenreForBookDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastGenreForBookDocument()
     {
         $genre = $this->bookReader->getLastGenre();
         self::assertGenreForBookDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenresByQueryForBookDocument()
     {
         $genres = $this->bookReader->getGenres('[@authority="marcgt"]');
@@ -70,72 +61,56 @@ class GenreReaderTest extends ModsReaderTest
         self::assertGenreForBookDocument($genres[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenreByQueryForBookDocument()
     {
         $genre = $this->bookReader->getGenre(0, '[@authority="marcgt"]');
         self::assertGenreForBookDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstGenreByQueryForBookDocument()
     {
         $genre = $this->bookReader->getFirstGenre('[@authority="marcgt"]');
         self::assertGenreForBookDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastGenreByQueryForBookDocument()
     {
         $genre = $this->bookReader->getLastGenre('[@authority="marcgt"]');
         self::assertGenreForBookDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoGenresByQueryForBookDocument()
     {
         $genres = $this->bookReader->getGenres('[@authority="merc"]');
         self::assertEmpty($genres);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoGenreByQueryForBookDocument()
     {
         $genre = $this->bookReader->getGenre(0, '[@authority="merc"]');
         self::assertNull($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstGenreByQueryForBookDocument()
     {
         $genre = $this->bookReader->getFirstGenre('[@authority="merc"]');
         self::assertNull($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastGenreByQueryForBookDocument()
     {
         $genre = $this->bookReader->getLastGenre('[@authority="merc"]');
         self::assertNull($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenresForSerialDocument()
     {
         $genres = $this->serialReader->getGenres();
@@ -144,36 +119,28 @@ class GenreReaderTest extends ModsReaderTest
         self::assertFirstGenreForSerialDocument($genres[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenreForSerialDocument()
     {
         $genre = $this->serialReader->getGenre(0);
         self::assertFirstGenreForSerialDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstGenreForSerialDocument()
     {
         $genre = $this->serialReader->getFirstGenre();
         self::assertFirstGenreForSerialDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastGenreForSerialDocument()
     {
         $genre = $this->serialReader->getLastGenre();
         self::assertSecondGenreForSerialDocument($genre);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getGenresByQueryForSerialDocument()
     {
         $genres = $this->serialReader->getGenres('[@usage="primary"]');
@@ -182,9 +149,7 @@ class GenreReaderTest extends ModsReaderTest
         self::assertFirstGenreForSerialDocument($genres[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoGenresByQueryForSerialDocument()
     {
         $genres = $this->serialReader->getGenres('[@type="xyz"]');

--- a/tests/Mods/Reader/IdentifierReaderTest.php
+++ b/tests/Mods/Reader/IdentifierReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Identifier;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class IdentifierReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifiersForBookDocument()
     {
         $identifiers = $this->bookReader->getIdentifiers();
@@ -32,36 +31,28 @@ class IdentifierReaderTest extends ModsReaderTest
         self::assertFirstIdentifierForBookDocument($identifiers[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierForBookDocument()
     {
         $identifier = $this->bookReader->getIdentifier(0);
         self::assertFirstIdentifierForBookDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstIdentifierForBookDocument()
     {
         $identifier = $this->bookReader->getFirstIdentifier();
         self::assertFirstIdentifierForBookDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastIdentifierForBookDocument()
     {
         $identifier = $this->bookReader->getLastIdentifier();
         self::assertSecondIdentifierForBookDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifiersByQueryForBookDocument()
     {
         $identifiers = $this->bookReader->getIdentifiers('[@type="lccn"]');
@@ -70,72 +61,56 @@ class IdentifierReaderTest extends ModsReaderTest
         self::assertSecondIdentifierForBookDocument($identifiers[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierByQueryForBookDocument()
     {
         $identifier = $this->bookReader->getIdentifier(0, '[@type="lccn"]');
         self::assertSecondIdentifierForBookDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstIdentifierByQueryForBookDocument()
     {
         $identifier = $this->bookReader->getFirstIdentifier('[@type="lccn"]');
         self::assertSecondIdentifierForBookDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastIdentifierByQueryForBookDocument()
     {
         $identifier = $this->bookReader->getLastIdentifier('[@type="lccn"]');
         self::assertSecondIdentifierForBookDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoIdentifiersByQueryForBookDocument()
     {
         $identifiers = $this->bookReader->getIdentifiers('[@type="xyz"]');
         self::assertEmpty($identifiers);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoIdentifierByQueryForBookDocument()
     {
         $identifier = $this->bookReader->getIdentifier(5, '[@type="lccn"]');
         self::assertNull($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstIdentifierByQueryForBookDocument()
     {
         $identifier = $this->bookReader->getFirstIdentifier('[@type="xyz"]');
         self::assertNull($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastIdentifierByQueryForBookDocument()
     {
         $identifier = $this->bookReader->getLastIdentifier('[@type="xyz"]');
         self::assertNull($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifiersForSerialDocument()
     {
         $identifiers = $this->serialReader->getIdentifiers();
@@ -144,36 +119,28 @@ class IdentifierReaderTest extends ModsReaderTest
         self::assertFirstIdentifierForSerialDocument($identifiers[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierForSerialDocument()
     {
         $identifier = $this->serialReader->getIdentifier(2);
         self::assertThirdIdentifierForSerialDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstIdentifierForSerialDocument()
     {
         $identifier = $this->serialReader->getFirstIdentifier();
         self::assertFirstIdentifierForSerialDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastIdentifierForSerialDocument()
     {
         $identifier = $this->serialReader->getLastIdentifier();
         self::assertFourthIdentifierForSerialDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifiersByQueryForSerialDocument()
     {
         $identifiers = $this->serialReader->getIdentifiers('[@type="issn"]');
@@ -182,63 +149,49 @@ class IdentifierReaderTest extends ModsReaderTest
         self::assertSecondIdentifierForSerialDocument($identifiers[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierByQueryForSerialDocument()
     {
         $identifier = $this->serialReader->getIdentifier(0, '[@type="issn"]');
         self::assertFirstIdentifierForSerialDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstIdentifierByQueryForSerialDocument()
     {
         $identifier = $this->serialReader->getFirstIdentifier('[@type="lccn"]');
         self::assertThirdIdentifierForSerialDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastIdentifierByQueryForSerialDocument()
     {
         $identifier = $this->serialReader->getLastIdentifier('[@type="lccn"]');
         self::assertThirdIdentifierForSerialDocument($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoIdentifiersByQueryForSerialDocument()
     {
         $identifiers = $this->serialReader->getIdentifiers('[@type="xyz"]');
         self::assertEmpty($identifiers);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoIdentifierByQueryForSerialDocument()
     {
         $identifier = $this->serialReader->getIdentifier(2, '[@type="xyz"]');
         self::assertNull($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstIdentifierByQueryForSerialDocument()
     {
         $identifier = $this->serialReader->getFirstIdentifier('[@type="xyz"]');
         self::assertNull($identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastIdentifierByQueryForSerialDocument()
     {
         $identifier = $this->serialReader->getLastIdentifier('[@type="xyz"]');

--- a/tests/Mods/Reader/LanguageReaderTest.php
+++ b/tests/Mods/Reader/LanguageReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Language;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class LanguageReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLanguagesForBookDocument()
     {
         $languages = $this->bookReader->getLanguages();
@@ -32,36 +31,28 @@ class LanguageReaderTest extends ModsReaderTest
         self::assertFirstLanguageForBookDocument($languages[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLanguageForBookDocument()
     {
         $language = $this->bookReader->getLanguage(0);
         self::assertFirstLanguageForBookDocument($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstLanguageForBookDocument()
     {
         $language = $this->bookReader->getFirstLanguage();
         self::assertFirstLanguageForBookDocument($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastLanguageForBookDocument()
     {
         $language = $this->bookReader->getLastLanguage();
         self::assertSecondLanguageForBookDocument($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLanguagesByQueryForBookDocument()
     {
         $languages = $this->bookReader->getLanguages('[@objectPart="summary"]');
@@ -70,72 +61,56 @@ class LanguageReaderTest extends ModsReaderTest
         self::assertSecondLanguageForBookDocument($languages[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLanguageByQueryForBookDocument()
     {
         $language = $this->bookReader->getLanguage(0, '[@objectPart="summary"]');
         self::assertSecondLanguageForBookDocument($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstLanguageByQueryForBookDocument()
     {
         $language = $this->bookReader->getFirstLanguage('[@objectPart="summary"]');
         self::assertSecondLanguageForBookDocument($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastLanguageByQueryForBookDocument()
     {
         $language = $this->bookReader->getLastLanguage('[@objectPart="summary"]');
         self::assertSecondLanguageForBookDocument($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLanguagesByQueryForBookDocument()
     {
         $languages = $this->bookReader->getLanguages('[@objectPart="abstract"]');
         self::assertEmpty($languages);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLanguageByQueryForBookDocument()
     {
         $language = $this->bookReader->getLanguage(0, '[@objectPart="abstract"]');
         self::assertNull($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstLanguageByQueryForBookDocument()
     {
         $language = $this->bookReader->getFirstLanguage('[@objectPart="abstract"]');
         self::assertNull($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastLanguageByQueryForBookDocument()
     {
         $language = $this->bookReader->getLastLanguage('[@objectPart="abstract"]');
         self::assertNull($language);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLanguagesForSerialDocument()
     {
         $languages = $this->serialReader->getLanguages();
@@ -144,9 +119,7 @@ class LanguageReaderTest extends ModsReaderTest
         self::assertLanguageForSerialDocument($languages[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLanguagesByQueryForSerialDocument()
     {
         $languages = $this->serialReader->getLanguages('[./mods:languageTerm[@type="code"]]');
@@ -155,9 +128,7 @@ class LanguageReaderTest extends ModsReaderTest
         self::assertLanguageForSerialDocument($languages[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLanguagesByQueryForSerialDocument()
     {
         $languages = $this->serialReader->getLanguages('[@objectPart="summary"]');

--- a/tests/Mods/Reader/LocationReaderTest.php
+++ b/tests/Mods/Reader/LocationReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Location;
 use Slub\Mods\Exception\IncorrectValueInAttributeException;
 use Slub\Mods\ModsReaderTest;
@@ -22,9 +23,7 @@ use Slub\Mods\ModsReaderTest;
 class LocationReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLocationsForBookDocument()
     {
         $locations = $this->bookReader->getLocations();
@@ -33,36 +32,28 @@ class LocationReaderTest extends ModsReaderTest
         self::assertFirstLocationForBookDocument($locations[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLocationForBookDocument()
     {
         $location = $this->bookReader->getLocation(1);
         self::assertSecondLocationForBookDocument($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstLocationForBookDocument()
     {
         $location = $this->bookReader->getFirstLocation();
         self::assertFirstLocationForBookDocument($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastLocationForBookDocument()
     {
         $location = $this->bookReader->getLastLocation();
         self::assertSecondLocationForBookDocument($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLocationsByQueryForBookDocument()
     {
         $locations = $this->bookReader->getLocations('[@displayLabel="links"]');
@@ -74,72 +65,56 @@ class LocationReaderTest extends ModsReaderTest
         $locations[0]->getUrls()[3]->getAccess();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLocationByQueryForBookDocument()
     {
         $location = $this->bookReader->getLocation(0, '[@displayLabel="links"]');
         self::assertSecondLocationForBookDocument($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetFirstLocationByQueryForBookDocument()
     {
         $location = $this->bookReader->getFirstLocation('[@displayLabel="links"]');
         self::assertSecondLocationForBookDocument($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastLocationForByQueryBookDocument()
     {
         $location = $this->bookReader->getLastLocation('[@displayLabel="links"]');
         self::assertSecondLocationForBookDocument($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLocationsByQueryForBookDocument()
     {
         $locations = $this->bookReader->getLocations('[@displayLabel="random"]');
         self::assertEmpty($locations);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLocationByQueryForBookDocument()
     {
         $location = $this->bookReader->getLocation(6, '[@displayLabel="links"]');
         self::assertNull($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstLocationByQueryForBookDocument()
     {
         $location = $this->bookReader->getFirstLocation('[@displayLabel="random"]');
         self::assertNull($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastLocationByQueryForBookDocument()
     {
         $location = $this->bookReader->getLastLocation('[@displayLabel="random"]');
         self::assertNull($location);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLocationsForSerialDocument()
     {
         $locations = $this->serialReader->getLocations();
@@ -148,9 +123,7 @@ class LocationReaderTest extends ModsReaderTest
         self::assertLocationForSerialDocument($locations[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLocationsByQueryForSerialDocument()
     {
         $locations = $this->serialReader->getLocations('[./mods:url[@usage="primaryDisplay"]]');
@@ -159,9 +132,7 @@ class LocationReaderTest extends ModsReaderTest
         self::assertLocationForSerialDocument($locations[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLocationsByQueryForSerialDocument()
     {
         $locations = $this->serialReader->getLocations('[@usage="rad"]');

--- a/tests/Mods/Reader/NameReaderTest.php
+++ b/tests/Mods/Reader/NameReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Name;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class NameReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNamesForBookDocument()
     {
         $names = $this->bookReader->getNames();
@@ -32,36 +31,28 @@ class NameReaderTest extends ModsReaderTest
         self::assertFirstNameForBookDocument($names[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNameForBookDocument()
     {
         $name = $this->bookReader->getName(1);
         self::assertSecondNameForBookDocument($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstNameForBookDocument()
     {
         $name = $this->bookReader->getFirstName();
         self::assertFirstNameForBookDocument($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastNameForBookDocument()
     {
         $name = $this->bookReader->getLastName();
         self::assertSecondNameForBookDocument($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNamesByQueryForBookDocument()
     {
         $names = $this->bookReader->getNames('[@type="personal" and not(@usage="primary")]');
@@ -70,72 +61,56 @@ class NameReaderTest extends ModsReaderTest
         self::assertSecondNameForBookDocument($names[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNameByQueryForBookDocument()
     {
         $name = $this->bookReader->getName(0, '[@type="personal" and not(@usage="primary")]');
         self::assertSecondNameForBookDocument($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstNameByQueryForBookDocument()
     {
         $name = $this->bookReader->getFirstName('[@type="personal" and not(@usage="primary")]');
         self::assertSecondNameForBookDocument($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastNameByQueryForBookDocument()
     {
         $name = $this->bookReader->getLastName('[@type="personal" and not(@usage="primary")]');
         self::assertSecondNameForBookDocument($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoNamesByQueryForBookDocument()
     {
         $names = $this->bookReader->getNames('[@type="corporate"]');
         self::assertEmpty($names);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoNameByQueryForBookDocument()
     {
         $name = $this->bookReader->getName(3, '[@type="corporate"]');
         self::assertNull($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstNameByQueryForBookDocument()
     {
         $name = $this->bookReader->getFirstName('[@type="corporate"]');
         self::assertNull($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastNameByQueryForBookDocument()
     {
         $name = $this->bookReader->getLastName('[@type="corporate"]');
         self::assertNull($name);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNamesForSerialDocument()
     {
         $names = $this->serialReader->getNames();
@@ -144,9 +119,7 @@ class NameReaderTest extends ModsReaderTest
         self::assertNameForSerialDocument($names[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNamesByQueryForSerialDocument()
     {
         $names = $this->serialReader->getNames('[@type="corporate"]');
@@ -155,9 +128,7 @@ class NameReaderTest extends ModsReaderTest
         self::assertNameForSerialDocument($names[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoNamesByQueryForSerialDocument()
     {
         $names = $this->serialReader->getNames('[@type="personal"]');

--- a/tests/Mods/Reader/NoteReaderTest.php
+++ b/tests/Mods/Reader/NoteReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Note;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class NoteReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNotesForBookDocument()
     {
         $notes = $this->bookReader->getNotes();
@@ -32,36 +31,28 @@ class NoteReaderTest extends ModsReaderTest
         self::assertFirstNoteForBookDocument($notes[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoteForBookDocument()
     {
         $note = $this->bookReader->getNote(1);
         self::assertSecondNoteForBookDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstNoteForBookDocument()
     {
         $note = $this->bookReader->getFirstNote();
         self::assertFirstNoteForBookDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastNoteForBookDocument()
     {
         $note = $this->bookReader->getLastNote();
         self::assertSecondNoteForBookDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNotesByQueryForBookDocument()
     {
         $notes = $this->bookReader->getNotes('[@type="bibliography"]');
@@ -70,72 +61,56 @@ class NoteReaderTest extends ModsReaderTest
         self::assertSecondNoteForBookDocument($notes[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoteByQueryForBookDocument()
     {
         $note = $this->bookReader->getNote(0, '[@type="bibliography"]');
         self::assertSecondNoteForBookDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstNoteByQueryForBookDocument()
     {
         $note = $this->bookReader->getFirstNote('[@type="bibliography"]');
         self::assertSecondNoteForBookDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastNoteByQueryForBookDocument()
     {
         $note = $this->bookReader->getLastNote('[@type="bibliography"]');
         self::assertSecondNoteForBookDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoNotesByQueryForBookDocument()
     {
         $notes = $this->bookReader->getNotes('[@type="xyz"]');
         self::assertEmpty($notes);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoNoteByQueryForBookDocument()
     {
         $note = $this->bookReader->getNote(0, '[@type="xyz"]');
         self::assertNull($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstNoteByQueryForBookDocument()
     {
         $note = $this->bookReader->getFirstNote('[@type="xyz"]');
         self::assertNull($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastNoteByQueryForBookDocument()
     {
         $note = $this->bookReader->getLastNote('[@type="xyz"]');
         self::assertNull($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNotesForSerialDocument()
     {
         $notes = $this->serialReader->getNotes();
@@ -144,36 +119,28 @@ class NoteReaderTest extends ModsReaderTest
         self::assertFirstNoteForSerialDocument($notes[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoteForSerialDocument()
     {
         $note = $this->serialReader->getNote(5);
         self::assertSixthNoteForSerialDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstNoteForSerialDocument()
     {
         $note = $this->serialReader->getFirstNote();
         self::assertFirstNoteForSerialDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastNoteForSerialDocument()
     {
         $note = $this->serialReader->getLastNote();
         self::assertSixthNoteForSerialDocument($note);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNotesByQueryForSerialDocument()
     {
         $notes = $this->serialReader->getNotes('[@type="system details"]');
@@ -182,9 +149,7 @@ class NoteReaderTest extends ModsReaderTest
         self::assertFifthNoteForSerialDocument($notes[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoNotesByQueryForSerialDocument()
     {
         $notes = $this->serialReader->getNotes('[@type="xyz"]');

--- a/tests/Mods/Reader/OriginInfoReaderTest.php
+++ b/tests/Mods/Reader/OriginInfoReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\OriginInfo;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class OriginInfoReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOriginInfosForBookDocument()
     {
         $originInfos = $this->bookReader->getOriginInfos();
@@ -32,36 +31,28 @@ class OriginInfoReaderTest extends ModsReaderTest
         self::assertFirstOriginInfoForBookDocument($originInfos[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOriginInfoForBookDocument()
     {
         $originInfo = $this->bookReader->getOriginInfo(1);
         self::assertSecondOriginInfoForBookDocument($originInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstOriginInfoForBookDocument()
     {
         $originInfo = $this->bookReader->getFirstOriginInfo();
         self::assertFirstOriginInfoForBookDocument($originInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastOriginInfoForBookDocument()
     {
         $originInfo = $this->bookReader->getLastOriginInfo();
         self::assertSecondOriginInfoForBookDocument($originInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOriginInfosByQueryForBookDocument()
     {
         $originInfos = $this->bookReader->getOriginInfos('[@eventType="redaction"]');
@@ -70,9 +61,7 @@ class OriginInfoReaderTest extends ModsReaderTest
         self::assertSecondOriginInfoForBookDocument($originInfos[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoOriginInfosByQueryForBookDocument()
     {
         $originInfos = $this->bookReader->getOriginInfos('[@eventType="xyz"]');
@@ -85,36 +74,28 @@ class OriginInfoReaderTest extends ModsReaderTest
         self::assertNull($lastOriginInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoOriginInfoByQueryForBookDocument()
     {
         $originInfo = $this->bookReader->getOriginInfo(4, '[@eventType="xyz"]');
         self::assertNull($originInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstOriginInfoByQueryForBookDocument()
     {
         $originInfo = $this->bookReader->getFirstOriginInfo('[@eventType="xyz"]');
         self::assertNull($originInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastOriginInfoByQueryForBookDocument()
     {
         $originInfo = $this->bookReader->getLastOriginInfo('[@eventType="xyz"]');
         self::assertNull($originInfo);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOriginInfosForSerialDocument()
     {
         $originInfos = $this->serialReader->getOriginInfos();
@@ -123,9 +104,7 @@ class OriginInfoReaderTest extends ModsReaderTest
         self::assertOriginInfoForSerialDocument($originInfos[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOriginInfosByQueryForSerialDocument()
     {
         $originInfos = $this->serialReader->getOriginInfos('[@eventType="publication"]');
@@ -134,9 +113,7 @@ class OriginInfoReaderTest extends ModsReaderTest
         self::assertOriginInfoForSerialDocument($originInfos[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoOriginInfosByQueryForSerialDocument()
     {
         $originInfos = $this->serialReader->getOriginInfos('[@eventType="xyz"]');

--- a/tests/Mods/Reader/PartReaderTest.php
+++ b/tests/Mods/Reader/PartReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Part;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class PartReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPartsForBookDocument()
     {
         $parts = $this->bookReader->getParts();
@@ -32,36 +31,28 @@ class PartReaderTest extends ModsReaderTest
         self::assertFirstPartForBookDocument($parts[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPartForBookDocument()
     {
         $part = $this->bookReader->getPart(1);
         self::assertSecondPartForBookDocument($part);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstPartForBookDocument()
     {
         $part = $this->bookReader->getFirstPart();
         self::assertFirstPartForBookDocument($part);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastPartForBookDocument()
     {
         $part = $this->bookReader->getLastPart();
         self::assertSecondPartForBookDocument($part);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPartsByQueryForBookDocument()
     {
         $parts = $this->bookReader->getParts('[@order="2"]');
@@ -70,45 +61,35 @@ class PartReaderTest extends ModsReaderTest
         self::assertSecondPartForBookDocument($parts[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoPartsByQueryForBookDocument()
     {
         $parts = $this->bookReader->getParts('[@order="3"]');
         self::assertEmpty($parts);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoPartByQueryForBookDocument()
     {
         $part = $this->bookReader->getPart(0, '[@order="3"]');
         self::assertNull($part);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstPartByQueryForBookDocument()
     {
         $part = $this->bookReader->getFirstPart('[@order="3"]');
         self::assertNull($part);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastPartByQueryForBookDocument()
     {
         $part = $this->bookReader->getLastPart('[@order="3"]');
         self::assertNull($part);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoPartsForSerialDocument()
     {
         $parts = $this->serialReader->getParts();

--- a/tests/Mods/Reader/PhysicalDescriptionReaderTest.php
+++ b/tests/Mods/Reader/PhysicalDescriptionReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\PhysicalDescription;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class PhysicalDescriptionReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPhysicalDescriptionsForBookDocument()
     {
         $physicalDescriptions = $this->bookReader->getPhysicalDescriptions();
@@ -32,36 +31,28 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
         self::assertPhysicalDescriptionForBookDocument($physicalDescriptions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPhysicalDescriptionForBookDocument()
     {
         $physicalDescription = $this->bookReader->getPhysicalDescription(0);
         self::assertPhysicalDescriptionForBookDocument($physicalDescription);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstPhysicalDescriptionForBookDocument()
     {
         $physicalDescription = $this->bookReader->getFirstPhysicalDescription();
         self::assertPhysicalDescriptionForBookDocument($physicalDescription);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastPhysicalDescriptionForBookDocument()
     {
         $physicalDescription = $this->bookReader->getLastPhysicalDescription();
         self::assertPhysicalDescriptionForBookDocument($physicalDescription);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function gtPhysicalDescriptionsByParametersForBookDocument()
     {
         $physicalDescriptions = $this->bookReader->getPhysicalDescriptionsByParameters('./mods:form', ['authority' => 'marcform'], 'print');
@@ -70,9 +61,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
         self::assertPhysicalDescriptionForBookDocument($physicalDescriptions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPhysicalDescriptionsByQueryForBookDocument()
     {
         $physicalDescriptions = $this->bookReader->getPhysicalDescriptions('[./mods:form[@authority="marcform"]="print"]');
@@ -81,45 +70,35 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
         self::assertPhysicalDescriptionForBookDocument($physicalDescriptions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoPhysicalDescriptionsByQueryForBookDocument()
     {
         $physicalDescriptions = $this->bookReader->getPhysicalDescriptions('[./mods:form[@authority="marcform"]="electronic"]');
         self::assertEmpty($physicalDescriptions);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoPhysicalDescriptionByQueryForBookDocument()
     {
         $physicalDescription = $this->bookReader->getPhysicalDescription(0, '[./mods:form[@authority="marcform"]="electronic"]');
         self::assertNull($physicalDescription);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstPhysicalDescriptionByQueryForBookDocument()
     {
         $physicalDescription = $this->bookReader->getFirstPhysicalDescription('[./mods:form[@authority="marcform"]="electronic"]');
         self::assertNull($physicalDescription);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastPhysicalDescriptionByQueryForBookDocument()
     {
         $physicalDescription = $this->bookReader->getLastPhysicalDescription('[./mods:form[@authority="marcform"]="electronic"]');
         self::assertNull($physicalDescription);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPhysicalDescriptionsForSerialDocument()
     {
         $physicalDescriptions = $this->serialReader->getPhysicalDescriptions();
@@ -128,9 +107,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
         self::assertPhysicalDescriptionForSerialDocument($physicalDescriptions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getPhysicalDescriptionsByQueryForSerialDocument()
     {
         $physicalDescriptions = $this->serialReader->getPhysicalDescriptions('[./mods:form[@authority="marcform"]="electronic"]');
@@ -139,9 +116,7 @@ class PhysicalDescriptionReaderTest extends ModsReaderTest
         self::assertPhysicalDescriptionForSerialDocument($physicalDescriptions[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoPhysicalDescriptionsByQueryForSerialDocument()
     {
         $physicalDescriptions = $this->serialReader->getPhysicalDescriptions('[./mods:form[@authority="marcform"]="print"]');

--- a/tests/Mods/Reader/RecordInfoReaderTest.php
+++ b/tests/Mods/Reader/RecordInfoReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\RecordInfo;
 use Slub\Mods\Exception\IncorrectValueInAttributeException;
 use Slub\Mods\ModsReaderTest;
@@ -22,7 +23,8 @@ use Slub\Mods\ModsReaderTest;
 class RecordInfoReaderTest extends ModsReaderTest
 {
 
-    public function testGetRecordInfosForBookDocument()
+    #[Test]
+    public function getRecordInfosForBookDocument()
     {
         $recordInfos = $this->bookReader->getRecordInfos();
         self::assertNotEmpty($recordInfos);
@@ -30,25 +32,29 @@ class RecordInfoReaderTest extends ModsReaderTest
         self::assertRecordInfoForBookDocument($recordInfos[0]);
     }
 
-    public function testGetRecordInfoForBookDocument()
+    #[Test]
+    public function getRecordInfoForBookDocument()
     {
         $recordInfo = $this->bookReader->getRecordInfo(0);
         self::assertRecordInfoForBookDocument($recordInfo);
     }
 
-    public function testGetFirstRecordInfoForBookDocument()
+    #[Test]
+    public function getFirstRecordInfoForBookDocument()
     {
         $recordInfo = $this->bookReader->getFirstRecordInfo();
         self::assertRecordInfoForBookDocument($recordInfo);
     }
 
-    public function testGetLastRecordInfoForBookDocument()
+    #[Test]
+    public function getLastRecordInfoForBookDocument()
     {
         $recordInfo = $this->bookReader->getLastRecordInfo();
         self::assertRecordInfoForBookDocument($recordInfo);
     }
 
-    public function testGetRecordInfosByQueryForBookDocument()
+    #[Test]
+    public function getRecordInfosByQueryForBookDocument()
     {
         $recordInfos = $this->bookReader->getRecordInfos('[./mods:descriptionStandard="aacr"]');
         self::assertNotEmpty($recordInfos);
@@ -56,31 +62,36 @@ class RecordInfoReaderTest extends ModsReaderTest
         self::assertRecordInfoForBookDocument($recordInfos[0]);
     }
 
-    public function testGetRecordInfoByQueryForBookDocument()
+    #[Test]
+    public function getRecordInfoByQueryForBookDocument()
     {
         $recordInfo = $this->bookReader->getRecordInfo(0, '[./mods:descriptionStandard="aacr"]');
         self::assertRecordInfoForBookDocument($recordInfo);
     }
 
-    public function testGetFirstRecordInfoByQueryForBookDocument()
+    #[Test]
+    public function getFirstRecordInfoByQueryForBookDocument()
     {
         $recordInfo = $this->bookReader->getFirstRecordInfo('[./mods:descriptionStandard="aacr"]');
         self::assertRecordInfoForBookDocument($recordInfo);
     }
 
-    public function testGetLastRecordInfoByQueryForBookDocument()
+    #[Test]
+    public function getLastRecordInfoByQueryForBookDocument()
     {
         $recordInfo = $this->bookReader->getLastRecordInfo('[./mods:descriptionStandard="aacr"]');
         self::assertRecordInfoForBookDocument($recordInfo);
     }
 
-    public function testGetNoRecordInfosByQueryForBookDocument()
+    #[Test]
+    public function getNoRecordInfosByQueryForBookDocument()
     {
         $recordInfos = $this->bookReader->getRecordInfos('[./mods:descriptionStandard="xyz"]');
         self::assertEmpty($recordInfos);
     }
 
-    public function testGetNoRecordInfoByQueryForBookDocument()
+    #[Test]
+    public function getNoRecordInfoByQueryForBookDocument()
     {
         $recordInfo = $this->bookReader->getRecordInfo(5, '[./mods:descriptionStandard="xyz"]');
         self::assertNull($recordInfo);
@@ -92,7 +103,8 @@ class RecordInfoReaderTest extends ModsReaderTest
         self::assertNull($lastRecordInfo);
     }
 
-    public function testGetRecordInfosForSerialDocument()
+    #[Test]
+    public function getRecordInfosForSerialDocument()
     {
         $recordInfos = $this->serialReader->getRecordInfos();
         self::assertNotEmpty($recordInfos);
@@ -103,7 +115,9 @@ class RecordInfoReaderTest extends ModsReaderTest
         $recordInfos[0]->getRecordCreationDates()[0]->getEncoding();
     }
 
-    public function testGetRecordInfosByQueryForSerialDocument()
+
+    #[Test]
+    public function getRecordInfosByQueryForSerialDocument()
     {
         $recordInfos = $this->serialReader->getRecordInfos('[./mods:descriptionStandard="aacr"]');
         self::assertNotEmpty($recordInfos);
@@ -114,7 +128,8 @@ class RecordInfoReaderTest extends ModsReaderTest
         $recordInfos[0]->getRecordCreationDates()[0]->getEncoding();
     }
 
-    public function testGetNoRecordInfosByQueryForSerialDocument()
+    #[Test]
+    public function getNoRecordInfosByQueryForSerialDocument()
     {
         $recordInfos = $this->serialReader->getRecordInfos('[./mods:descriptionStandard="xyz"]');
         self::assertEmpty($recordInfos);

--- a/tests/Mods/Reader/RelatedItemReaderTest.php
+++ b/tests/Mods/Reader/RelatedItemReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\RelatedItem;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,45 +22,35 @@ use Slub\Mods\ModsReaderTest;
 class RelatedItemReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoRelatedItemsForBookDocument()
     {
         $relatedItems = $this->bookReader->getRelatedItems();
         self::assertEmpty($relatedItems);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoRelatedItemForBookDocument()
     {
         $relatedItem = $this->bookReader->getRelatedItem(0);
         self::assertNull($relatedItem);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstRelatedItemForBookDocument()
     {
         $relatedItem = $this->bookReader->getFirstRelatedItem();
         self::assertNull($relatedItem);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastRelatedItemForBookDocument()
     {
         $relatedItem = $this->bookReader->getLastRelatedItem();
         self::assertNull($relatedItem);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRelatedItemsForSerialDocument()
     {
         $relatedItems = $this->serialReader->getRelatedItems();
@@ -68,36 +59,28 @@ class RelatedItemReaderTest extends ModsReaderTest
         self::assertRelatedItemForSerialDocument($relatedItems[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRelatedItemForSerialDocument()
     {
         $relatedItem = $this->serialReader->getRelatedItem(0);
         self::assertRelatedItemForSerialDocument($relatedItem);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstRelatedItemForSerialDocument()
     {
         $relatedItem = $this->serialReader->getFirstRelatedItem();
         self::assertRelatedItemForSerialDocument($relatedItem);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastRelatedItemForSerialDocument()
     {
         $relatedItem = $this->serialReader->getLastRelatedItem();
         self::assertRelatedItemForSerialDocument($relatedItem);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRelatedItemsByQueryForSerialDocument()
     {
         $relatedItems = $this->serialReader->getRelatedItems('[./mods:identifier="1525-321X"]');
@@ -106,9 +89,7 @@ class RelatedItemReaderTest extends ModsReaderTest
         self::assertRelatedItemForSerialDocument($relatedItems[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoRelatedItemsByQueryForSerialDocument()
     {
         $relatedItems = $this->serialReader->getRelatedItems('[./mods:identifier="15-32"]');

--- a/tests/Mods/Reader/SubjectReaderTest.php
+++ b/tests/Mods/Reader/SubjectReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\Subject;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class SubjectReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubjectsForBookDocument()
     {
         $subjects = $this->bookReader->getSubjects();
@@ -32,36 +31,28 @@ class SubjectReaderTest extends ModsReaderTest
         self::assertFirstSubjectForBookDocument($subjects[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubjectForBookDocument()
     {
         $subjects = $this->bookReader->getSubject(1);
         self::assertSecondSubjectForBookDocument($subjects);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstSubjectForBookDocument()
     {
         $subjects = $this->bookReader->getFirstSubject();
         self::assertFirstSubjectForBookDocument($subjects);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastSubjectForBookDocument()
     {
         $subjects = $this->bookReader->getLastSubject();
         self::assertEightSubjectForBookDocument($subjects);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubjectsByQueryForBookDocument()
     {
         $subjects = $this->bookReader->getSubjects('[./mods:topic="Mass media"]');
@@ -70,72 +61,56 @@ class SubjectReaderTest extends ModsReaderTest
         self::assertFourthSubjectForBookDocument($subjects[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubjectByQueryForBookDocument()
     {
         $subject = $this->bookReader->getSubject(0, '[./mods:topic="Mass media"]');
         self::assertFourthSubjectForBookDocument($subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstSubjectByQueryForBookDocument()
     {
         $subject = $this->bookReader->getFirstSubject('[./mods:topic="Mass media"]');
         self::assertFourthSubjectForBookDocument($subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastSubjectByQueryForBookDocument()
     {
         $subject = $this->bookReader->getLastSubject('[./mods:topic="Mass media"]');
         self::assertFourthSubjectForBookDocument($subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoSubjectsByQueryForBookDocument()
     {
         $subjects = $this->bookReader->getSubjects('[./mods:topic="Unknown"]');
         self::assertEmpty($subjects);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoSubjectByQueryForBookDocument()
     {
         $subject = $this->bookReader->getSubject(5, '[./mods:topic="Unknown"]');
         self::assertNull($subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstSubjectByQueryForBookDocument()
     {
         $subject = $this->bookReader->getFirstSubject(5, '[./mods:topic="Unknown"]');
         self::assertNull($subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastSubjectByQueryForBookDocument()
     {
         $subject = $this->bookReader->getLastSubject('[./mods:topic="Unknown"]');
         self::assertNull($subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubjectsForSerialDocument()
     {
         $subjects = $this->serialReader->getSubjects();
@@ -153,9 +128,7 @@ class SubjectReaderTest extends ModsReaderTest
         */
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSubjectsByQueryForSerialDocument()
     {
         $subjects = $this->serialReader->getSubjects('[./mods:genre="Directories"]');
@@ -168,9 +141,7 @@ class SubjectReaderTest extends ModsReaderTest
         self::assertEquals('Directories', $subjects[0]->getGenres()[0]->getValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoSubjectsByQueryForSerialDocument()
     {
         $subjects = $this->serialReader->getSubjects('[./mods:topic="Unknown"]');

--- a/tests/Mods/Reader/TableOfContentsReaderTest.php
+++ b/tests/Mods/Reader/TableOfContentsReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\TableOfContents;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,9 +22,7 @@ use Slub\Mods\ModsReaderTest;
 class TableOfContentsReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTablesOfContentsForBookDocument()
     {
         $tablesOfContents = $this->bookReader->getTablesOfContents();
@@ -32,36 +31,28 @@ class TableOfContentsReaderTest extends ModsReaderTest
         self::assertTableOfContentsForBookDocument($tablesOfContents[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTableOfContentsForBookDocument()
     {
         $tableOfContents = $this->bookReader->getTableOfContents(0);
         self::assertTableOfContentsForBookDocument($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstTableOfContentsForBookDocument()
     {
         $tableOfContents = $this->bookReader->getFirstTableOfContents();
         self::assertTableOfContentsForBookDocument($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastTableOfContentsForBookDocument()
     {
         $tableOfContents = $this->bookReader->getLastTableOfContents();
         self::assertTableOfContentsForBookDocument($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTablesOfContentsByQueryForBookDocument()
     {
         $tablesOfContents = $this->bookReader->getTablesOfContents('[@displayLabel="Chapters"]');
@@ -70,72 +61,56 @@ class TableOfContentsReaderTest extends ModsReaderTest
         self::assertTableOfContentsForBookDocument($tablesOfContents[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTableOfContentsByQueryForBookDocument()
     {
         $tableOfContents = $this->bookReader->getTableOfContents(0, '[@displayLabel="Chapters"]');
         self::assertTableOfContentsForBookDocument($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getFirstTableOfContentsByQueryForBookDocument()
     {
         $tableOfContents = $this->bookReader->getFirstTableOfContents('[@displayLabel="Chapters"]');
         self::assertTableOfContentsForBookDocument($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLastTableOfContentsByQueryForBookDocument()
     {
         $tableOfContents = $this->bookReader->getLastTableOfContents('[@displayLabel="Chapters"]');
         self::assertTableOfContentsForBookDocument($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoTablesOfContentsByQueryForBookDocument()
     {
         $tablesOfContents = $this->bookReader->getTablesOfContents('[@displayLabel="Pages"]');
         self::assertEmpty($tablesOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoTableOfContentsByQueryForBookDocument()
     {
         $tableOfContents = $this->bookReader->getTableOfContents(0, '[@displayLabel="Pages"]');
         self::assertNull($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoFirstTableOfContentsByQueryForBookDocument()
     {
         $tableOfContents = $this->bookReader->getFirstTableOfContents('[@displayLabel="Pages"]');
         self::assertNull($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoLastTableOfContentsByQueryForBookDocument()
     {
         $tableOfContents = $this->bookReader->getLastTableOfContents('[@displayLabel="Pages"]');
         self::assertNull($tableOfContents);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoTablesOfContentsForSerialDocument()
     {
         $tablesOfContents = $this->serialReader->getTablesOfContents();

--- a/tests/Mods/Reader/TitleInfoReaderTest.php
+++ b/tests/Mods/Reader/TitleInfoReaderTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\ModsReaderTest;
 
 /**
@@ -20,10 +21,8 @@ use Slub\Mods\ModsReaderTest;
 class TitleInfoReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
-    public function testGetTitleInfosForBookDocument()
+    #[Test]
+    public function getTitleInfosForBookDocument()
     {
         $titleInfos = $this->bookReader->getTitleInfos();
         self::assertNotEmpty($titleInfos);
@@ -33,10 +32,8 @@ class TitleInfoReaderTest extends ModsReaderTest
         self::assertEquals('the making of the punditocracy', $titleInfos[0]->getSubTitle()->getValue());
     }
 
-    /**
-     * @test
-     */
-    public function testGetTitleInfosByQueryForBookDocument()
+    #[Test]
+    public function getTitleInfosByQueryForBookDocument()
     {
         $titleInfos = $this->bookReader->getTitleInfos('[@xml:lang="fr"]');
         self::assertNotEmpty($titleInfos);
@@ -52,10 +49,8 @@ class TitleInfoReaderTest extends ModsReaderTest
         self::assertEquals('la création de la punditocratie', $titleInfos[0]->getSubTitle()->getValue());
     }
 
-    /**
-     * @test
-     */
-    public function testGetTitleInfosForSerialDocument()
+    #[Test]
+    public function getTitleInfosForSerialDocument()
     {
         $titleInfos = $this->serialReader->getTitleInfos();
         self::assertNotEmpty($titleInfos);
@@ -67,10 +62,8 @@ class TitleInfoReaderTest extends ModsReaderTest
         self::assertEquals('the electronic journal of academic and special librarianship', $titleInfos[0]->getSubTitle()->getValue());
     }
 
-    /**
-     * @test
-     */
-    public function testGetTitleInfosByQueryForSerialDocument()
+    #[Test]
+    public function getTitleInfosByQueryForSerialDocument()
     {
         $titleInfos = $this->serialReader->getTitleInfos('[@type="abbreviated"]');
         self::assertNotEmpty($titleInfos);
@@ -81,10 +74,8 @@ class TitleInfoReaderTest extends ModsReaderTest
         self::assertEquals('(Athabasca)', $titleInfos[0]->getSubTitle()->getValue());
     }
 
-    /**
-     * @test
-     */
-    public function testGetNoTitleInfosByQueryForSerialDocument()
+    #[Test]
+    public function getNoTitleInfosByQueryForSerialDocument()
     {
         $titleInfos = $this->serialReader->getTitleInfos('[@type="uniform"]');
         self::assertEmpty($titleInfos);

--- a/tests/Mods/Reader/TypeOfResourceTest.php
+++ b/tests/Mods/Reader/TypeOfResourceTest.php
@@ -12,6 +12,7 @@
 
 namespace Slub\Mods\Reader;
 
+use PHPUnit\Framework\Attributes\Test;
 use Slub\Mods\Element\TypeOfResource;
 use Slub\Mods\ModsReaderTest;
 
@@ -21,36 +22,28 @@ use Slub\Mods\ModsReaderTest;
 class TypeOfResourceReaderTest extends ModsReaderTest
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTypeOfResourceForBookDocument()
     {
         $typeOfResource = $this->bookReader->getTypeOfResource();
         self::assertTypeOfResourceForBookDocument($typeOfResource);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTypeOfResourceByQueryForBookDocument()
     {
         $typeOfResource = $this->bookReader->getTypeOfResource('[@displayLabel="format"]');
         self::assertTypeOfResourceForBookDocument($typeOfResource);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoTypeOfResourceByQueryForBookDocument()
     {
         $typeOfResource = $this->bookReader->getTypeOfResource('[@displayLabel="random"]');
         self::assertNull($typeOfResource);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTypeOfResourceForSerialDocument()
     {
         $typeOfResource = $this->serialReader->getTypeOfResource();
@@ -60,9 +53,7 @@ class TypeOfResourceReaderTest extends ModsReaderTest
         self::assertEquals('text', $typeOfResource->getValue());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getNoTypeOfResourceByQueryForSerialDocument()
     {
         $abstract = $this->serialReader->getAbstract('[@displayForm="format"]');

--- a/tests/Mods/Utility/QueryTest.php
+++ b/tests/Mods/Utility/QueryTest.php
@@ -11,6 +11,7 @@
  */
 namespace Slub\Mods\Utility;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class QueryTest extends TestCase
@@ -76,9 +77,7 @@ class QueryTest extends TestCase
         ]
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testConstructorAppendsCorrectXpath()
     {
         $initialXPath = '/initial/xpath';


### PR DESCRIPTION
Drop support for PHP 7.4, making PHP 8.2 the new minimum requirement for the project.

This update also includes bumping PHPStan and PHPUnit to their latest major versions, ensuring compatibility with modern PHP environments and leveraging new features from these development tools.